### PR TITLE
WebDriverCookie "secure" flag read from WebDriverCookie

### DIFF
--- a/src/Cookie/CookieJar.php
+++ b/src/Cookie/CookieJar.php
@@ -116,7 +116,7 @@ final class CookieJar extends BaseCookieJar
             $webDriverCookie->setHttpOnly(true);
         }
 
-        if ($webDriverCookie->isSecure()) {
+        if ($cookie->isSecure()) {
             $webDriverCookie->setSecure(true);
         }
 


### PR DESCRIPTION
In the function `symfonyToWebDriver` in `CookieJar.php` the value `secure` of a cookie is read from `$webDriverCookie` and then also set on `$webDriverCookie`. I think this should be read from the symfony `$cookie` variable.